### PR TITLE
Fix inverted images

### DIFF
--- a/search/search.user.css
+++ b/search/search.user.css
@@ -7811,6 +7811,24 @@
 			}
 }
 
+/* Fix inverted images */
+
+.gb_nc span{
+	filter: invert(1);
+}
+
+.gb_nc .gbip{
+	filter: invert(1);
+}
+
+.gb_nc img{
+	filter: invert(1);
+}
+
+.gb_nc .gb_Kb{
+	background: inherit;
+}
+
 /* remove place */
 @-moz-document regexp("https?://www\.google\.(com|([a-z]{2}))(\.[a-z]{2})?/local/place/rap/editattribute.*") {
 	:root {


### PR DESCRIPTION
The parent div for these images is being inverted. Inverting the images themselves again will un-invert them.

Just added these CSS rules:

```
.gb_nc span{
	filter: invert(1);
}

.gb_nc .gbip{
	filter: invert(1);
}

.gb_nc img{
	filter: invert(1);
}

.gb_nc .gb_Kb{
	background: inherit;
}
```

.... and it's fixed:
![24_08-48-346x615-52e57caa8e 1](https://user-images.githubusercontent.com/13846271/56623268-811b5a80-666e-11e9-8bd9-86e8b0bd8696.png)
